### PR TITLE
Correct new invocation of Cache

### DIFF
--- a/stdlib/ballerina-builtin/src/main/ballerina/auth.utils/auth-utils.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/auth.utils/auth-utils.bal
@@ -51,7 +51,8 @@ public function createCache (string cacheName) returns (caching:Cache|()) {
         int capacity;
         float evictionFactor;
         (expiryTime, capacity, evictionFactor) = getCacheConfigurations(cacheName);
-        return new(expiryTimeMillis = expiryTime, capacity = capacity, evictionFactor = evictionFactor);
+        caching:Cache cache = new (expiryTimeMillis = expiryTime, capacity = capacity, evictionFactor = evictionFactor);
+        return cache;
     }
     return ();
 }


### PR DESCRIPTION
## Purpose
> When `return new(-)` syntax is used, the compiler does not complain. However, it is not clear if this is a valid new operation. Can it check the return type and do the newing based on the return type. However, doing new like this will result in symbols not generated for variables such as "expiryTime". Even if such variables were removed, invocation-symbol of new operation is null. Hence, even if taint-analyzer succeed this might not function. 

## Goals
> Correct compilation issue due to taint analyzer NPE.

## Approach
> Corrected new operation to new the caching:Cache type. 